### PR TITLE
AO-12: Update documentation to point to Add Ons instead of Modulus

### DIFF
--- a/en/Appendices/appendixB.md
+++ b/en/Appendices/appendixB.md
@@ -65,7 +65,7 @@
 
 **Module:** A software package that extends or changes OpenMRS functionality without interfering with core OpenMRS code and have full access to OpenMRS.
 
-**Module repository:** An online resource to find and maintain community-developed OpenMRS add-on modules. http://modules.openmrs.org/
+**Module repository:** An online resource to find and maintain community-developed OpenMRS add-on modules. [https://addons.openmrs.org/](https://addons.openmrs.org/)
 
 **MySQL:** An open source relational database management system (RDMS) popular with web application and used by OpenMRS. 
 

--- a/en/Case_study/yourFirstModule.md
+++ b/en/Case_study/yourFirstModule.md
@@ -451,6 +451,5 @@ Once your module is released, you may think that your work is over. However, the
 
 When done with developing and testing your module, you can release it for developers by deploying to the Maven repository using instructions at: http://om.rs/newdevtagging
 
-For end users, you can upload it to the module repository http://modules.openmrs.org which is available to everyone. Read more about our rules and regulations for it here: http://om.rs/newdevmodrepo 
-
+For end users, you can release your module via GitHub Releases, Bintray, Maven, etc. Now, your published module will be added to the [Add-ons index](https://addons.openmrs.org/), which is available to everyone. Read more on the [Module Release process here](https://wiki.openmrs.org/x/zIMmAQ). Also read more about our rules and regulations for it here: http://om.rs/newdevmodrepo 
  


### PR DESCRIPTION
https://issues.openmrs.org/browse/AO-12

I fixed https://modules.openmrs.org links which should be updated to the new https://addons.openmrs.org/ .